### PR TITLE
Replace pyquery.PyQuery with lxml.etree

### DIFF
--- a/route.py
+++ b/route.py
@@ -1,4 +1,3 @@
-from pyquery import PyQuery as pq
 from lxml import etree
 import requests
 import uuid
@@ -12,19 +11,21 @@ def get_services(route):
 	agency_id = route[1]
 	route_tag = route[2]
 	# Hit the routeConfig endpoint.
-	route_config_pq = pq(requests.get(
+	route_config_xml = requests.get(
 		'http://webservices.nextbus.com/service/publicXMLFeed?command=routeConfig&a={0}&r={1}&verbose=true'.format(
-			agency_id, route_tag)).content
-	)
+			agency_id, route_tag
+		)
+	).content
+	route_config_etree = etree.fromstring(route_config_xml)
 	# Format the route's services as a list of tuples for psycopg2.
 	service_rows = [(
 		uuid.uuid4(),
 		route_id,
-		i.attr('tag'),
-		i.attr('title'),
-		i.attr('name'),
-		i.attr('useForUI') == 'true'
-	) for i in route_config_pq.items('direction')]
+		i.get('tag'),
+		i.get('title'),
+		i.get('name'),
+		i.get('useForUI') == 'true'
+	) for i in route_config_etree.iter('direction')]
 	# Include a NULL service tag, used for vehicles that are not currently running a service.
 	service_rows.extend([(uuid.uuid4(), route_id, None, None, None, False)])
 	# Return the list of service tuples.
@@ -39,23 +40,25 @@ def get_stops(route):
 	agency_id = route[1]
 	route_tag = route[2]
 	# Hit the routeConfig endpoint.
-	route_config_pq = pq(requests.get(
+	route_config_xml = requests.get(
 		'http://webservices.nextbus.com/service/publicXMLFeed?command=routeConfig&a={0}&r={1}&verbose=true'.format(
-			agency_id, route_tag)).content
-	)
+			agency_id, route_tag
+		)
+	).content
+	route_config_etree = etree.fromstring(route_config_xml)
 	# Format the route's stops as a list of tuples for psycopg2.
 	# These will be passed to the mogrify function so that postgis commands can be wrapped around them.
 	stop_rows = [(
 		uuid.uuid4(),
 		route_id,
-		i.attr('tag'),
-		i.attr('title'),
-		i.attr('lon'),
-		i.attr('lat')
-	) for i in route_config_pq.items('body > route > stop')]
+		i.get('tag'),
+		i.get('title'),
+		i.get('lon'),
+		i.get('lat')
+	) for i in route_config_etree.xpath('//body/route/stop')]
 	# Record the "missing stops": those that show up somewhere in the XML, but not in the body.
 	# Store them as a set to avoid duplicates.
-	all_stops     = set(i.attr('tag') for i in route_config_pq.items('stop'))
+	all_stops     = set(i.get('tag') for i in route_config_etree.iter('stop'))
 	missing_stops = set((route_id, s) for s in all_stops \
 		if s not in [sa[2] for sa in stop_rows])
 	# Return a list with (1) the stop_rows list and (2) the missing_stops set
@@ -70,10 +73,12 @@ def get_service_stop_orders(conn, route):
 	# Get the current UTC datetime.
 	now = datetime.datetime.utcnow()
 	# Hit the routeConfig endpoint.
-	route_config_pq = pq(requests.get(
+	route_config_xml = requests.get(
 		'http://webservices.nextbus.com/service/publicXMLFeed?command=routeConfig&a={0}&r={1}&verbose=true'.format(
-			agency_id, route_tag)).content
-	)
+			agency_id, route_tag
+		)
+	).content
+	route_config_etree = etree.fromstring(route_config_xml)
 	# Get all services running on and stops lying on the current route.
 	with conn.cursor() as cur:
 		# Get services.
@@ -88,10 +93,10 @@ def get_service_stop_orders(conn, route):
 	# Initiate a list to store the direction stop orders on the "routeConfig" endpoint results.
 	stop_orders = []
 	# Add the service stop orders for each service (or "direction" on the endpoint results).
-	for i in route_config_pq.items('direction'):
+	for i in route_config_etree.iter('direction'):
 		stop_order = 1
-		for j in i.items('stop'):
-			stop_orders.extend([(i.attr('tag'), j.attr('tag'), stop_order)])
+		for j in i.iter('stop'):
+			stop_orders.extend([(i.get('tag'), j.get('tag'), stop_order)])
 			stop_order += 1
 	# Use the dicts to find the service and stop UUIDs, and return the resulting list of tuples.
 	stop_order_rows = [(
@@ -111,13 +116,13 @@ def get_vehicle_locations(conn, route, service_dict, route_service_dict, previou
 	# Hit the vehicleLocations endpoint.
 	vehicle_xml = requests.get(
 		'http://webservices.nextbus.com/service/publicXMLFeed?command=vehicleLocations&a={0}&r={1}&t={2}'.format(
-			agency_id, route_tag, previous_request)).content
-	vehicle_pq = pq(vehicle_xml)
-	vehicle_etreee = etree.fromstring(vehicle_xml)
+			agency_id, route_tag, previous_request
+		)
+	).content
+	vehicle_etree = etree.fromstring(vehicle_xml)
 	# Get the time (in epoch microseconds since 1970) of this API request.
 	# This will be returned along with the vehicle locations.
 	try:
-		# this_request = vehicle_pq.children().not_('vehicle').attr('time')
 		this_request = vehicle_etree.find('lastTime').get('time')
 		# Convert to a UTC datetime representation. This will be used to populate the location_datetime field.
 		request_datetime = datetime.datetime.utcfromtimestamp(round(float(this_request) / 1000))	
@@ -127,40 +132,40 @@ def get_vehicle_locations(conn, route, service_dict, route_service_dict, previou
 	# Initiate the list of tuples that will contain the route's vehicle locations.
 	vehicle_rows = []
 	# Loop through each vehicle to create its tuple of column values for postgres.
-	for i in vehicle_pq.items('vehicle'):
+	for i in vehicle_etree.iter('vehicle'):
 		# Match 'dirTag's to service UUIDs as follows:
 		#   (1) Try to find 'dirTag' in the route_service_dict.
 		#   (2) If (1) doesn't work, try to find 'dirTag' in the agency-wide service_dict.
 		#   (3) If (2) doesn't work, skip to the next vehicle in the for loop.
 		try:
-			service_id = route_service_dict[i.attr('dirTag')]
+			service_id = route_service_dict[i.get('dirTag')]
 		except:
 			try:
-				service_id = service_dict[i.attr('dirTag')]
+				service_id = service_dict[i.get('dirTag')]
 			except:
-				print(i.attr('dirTag') + " is not a valid service tag for agency " + agency_id)
+				print(i.get('dirTag') + " is not a valid service tag for agency " + agency_id)
 				continue
 		# If the speed is not a valid float, set to NULL.
 		try:
-			vehicle_speed = float(i.attr('speedKmHr'))
+			vehicle_speed = float(i.get('speedKmHr'))
 		except:
 			vehicle_speed = None
 		# If the direction is not a valid float, set to NULL.
 		try:
-			vehicle_direction = float(i.attr('heading'))
+			vehicle_direction = float(i.get('heading'))
 		except:
 			vehicle_direction = None
 		# Extend the vehicle_rows list to include a tuple containing this vehicle's most recent
 		# location and other information.
 		vehicle_rows.extend([(
 			service_id,
-			i.attr('id'),
-			i.attr('lon'),
-			i.attr('lat'),
+			i.get('id'),
+			i.get('lon'),
+			i.get('lat'),
 			vehicle_direction if (vehicle_direction is None) or (0 <= vehicle_direction <= 360) else None,
 			vehicle_speed if (vehicle_speed is None) or (vehicle_speed >= 0) else None,
-			request_datetime - datetime.timedelta(seconds = float(i.attr('secsSinceReport'))),
-			i.attr('predictable') == 'true'
+			request_datetime - datetime.timedelta(seconds = float(i.get('secsSinceReport'))),
+			i.get('predictable') == 'true'
 		)])
 	# Return the vehicle rows, and the epoch time of the API request.
 	return [vehicle_rows, this_request]


### PR DESCRIPTION
Replace the `pyquery` module with the `lxml` module. `pyquery` wasn't recognizing the `lastTime` element in the `vehicleLocations` endpoint XML; `lxml` didn't have this problem.

I also suspected that the mysterious "random missing stops"1 were a result of an unexplained inconsistency in `pyquery`, but this turned out to be wrong; this bug is still popping up with `lxml`, and I haven't figured it out yet. Still working on it.

1 - *Mysterious "random missing stops"*: some `stop`s (and more rarely `service`s) are not being inserted to the database. This throws an error later, when python fails while trying to create `service_stop_order`s because a dict() call uses a key (a stop (or service) `tag`) that doesn't exist. The key doesn't exist because that route's stops (or services) weren't inserted to the database. The offending routes are different every time, which is the real head-scratching part. And sometimes the issue doesn't pop up, or if I run `run.py` multiple times, eventually all stops and services will be added. The issue has something to do with either (1) retrieving the XML from the API or (2) parsing the XML, because I noticed that when a particular route's services are missing, that route's `NULL` service (created manually in a later line of python code) isn't missing.