### PR TITLE
Remove vehicle direction and speed

### DIFF
--- a/agency.py
+++ b/agency.py
@@ -305,22 +305,19 @@ def update_vehicle_locations(conn, agency_id, previous_requests):
             # Wrap postgis command around the lon and lat of each
             # vehicle.
             vehicle_rows_str = b','.join(cur.mogrify(
-                "(%s, %s, ST_SetSRID(ST_MakePoint(%s, %s), 4326), "
-                + "%s::numeric, %s::numeric, %s, %s)",
+                "(%s, %s, ST_SetSRID(ST_MakePoint(%s, %s), 4326), %s, %s)",
                 i
             ) for i in vehicle_rows).decode(conn.encoding)
             # Execute the INSERT command.
             cur.execute(
                 "INSERT INTO nextbus.vehicle_location "
                 + "(service_id, vehicle_tag, vehicle_location, "
-                + "vehicle_direction, vehicle_speed, location_timestamp, "
-                + "is_predictable) "
+                + "location_timestamp, is_predictable) "
                 + "SELECT DISTINCT ON "
                 + "(service_id, vehicle_tag, location_timestamp) * "
                 + "FROM (VALUES "
                 + vehicle_rows_str
                 + ") v(service_id, vehicle_tag, vehicle_location, "
-                + "vehicle_direction, vehicle_speed, "
                 + "location_timestamp, is_predictable)"
             )
     # Return the updated API request epoch times.

--- a/route.py
+++ b/route.py
@@ -192,16 +192,6 @@ def get_vehicle_locations(conn, route, service_dict,
                     + agency_id
                 )
                 continue
-        # If the speed is not a valid float, set to NULL.
-        try:
-            vehicle_speed = float(i.get('speedKmHr'))
-        except:
-            vehicle_speed = None
-        # If the direction is not a valid float, set to NULL.
-        try:
-            vehicle_direction = float(i.get('heading'))
-        except:
-            vehicle_direction = None
         # Extend the vehicle_rows list to include a tuple containing
         # this vehicle's most recent location and other information.
         vehicle_rows.extend([(
@@ -209,8 +199,6 @@ def get_vehicle_locations(conn, route, service_dict,
             i.get('id'),
             i.get('lon'),
             i.get('lat'),
-            vehicle_direction if (vehicle_direction is None) or (0 <= vehicle_direction <= 360) else None,
-            vehicle_speed if (vehicle_speed is None) or (vehicle_speed >= 0) else None,
             request_datetime - datetime.timedelta(seconds=float(i.get('secsSinceReport'))),
             i.get('predictable') == 'true'
         )])

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -112,23 +112,14 @@ CREATE TABLE IF NOT EXISTS nextbus.service_stop_order (
 /*
 Create vehicle_location table.
 This table shows every updated vehicle GPS location from nextbus.
-It also records other vehicle information provided by nextbus.
 */
--- The vehicle_direction must be a valid "degree" angle between 0-360.
--- The vehicle_speed must be nonnegative.
 CREATE TABLE IF NOT EXISTS nextbus.vehicle_location (
 	service_id         UUID,
 	vehicle_tag        TEXT,
 	vehicle_location   GEOMETRY(POINT, 4326),
-	vehicle_direction  NUMERIC,
-	vehicle_speed      NUMERIC,
 	location_timestamp TIMESTAMP,
 	is_predictable     BOOLEAN,
 	CONSTRAINT vehicle_provides_service_fk
 		FOREIGN KEY (service_id)
-		REFERENCES nextbus.service (service_id),
-	CONSTRAINT vehicle_direction_is_angle_chk
-		CHECK (vehicle_direction  BETWEEN 0 AND 360),
-	CONSTRAINT vehicle_speed_is_nonnegative_chk
-		CHECK (vehicle_speed >= 0)
+		REFERENCES nextbus.service (service_id)
 );


### PR DESCRIPTION
This is a simple PR to remove the `vehicle_direction` (`heading` in the NextBus API) and `vehicle_speed` (`speedKmHr` in the NextBus API) columns from the package. This resolves #4 - my rationale is spelled out there.

The Python scripts have been tested on an updated version of the database that no longer has these 2 columns. They worked without error.